### PR TITLE
Give docker build a build context

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,5 +6,5 @@ cp "$GITHUB_EVENT_PATH" event.json
 cat event.json
 ls -lah
 
-echo -e "FROM beeceej/lgtm:${latest_tag}\nADD . .\nENTRYPOINT [ \"/bin/lgtm\" ]" | docker build --rm -t runtime -
+echo -e "FROM beeceej/lgtm:${latest_tag}\nADD . .\nENTRYPOINT [ \"/bin/lgtm\" ]" | docker build --rm -t runtime  -f - .
 docker run --rm -e GH_TOKEN -e GITHUB_EVENT_PATH="./event.json" runtime:latest


### PR DESCRIPTION
This fancy docker command somehow wasn't passing a build context to the docker image, so nothing was in the runtime image